### PR TITLE
fix: Except and isActionImportant are working again.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,9 +9,8 @@ import { PluginConfig } from "./pluginConfig"
 
 function reactotronRedux(pluginConfig: PluginConfig = {}) {
   const mergedPluginConfig: PluginConfig = {
+    ...pluginConfig,
     restoreActionType: pluginConfig.restoreActionType || DEFAULT_REPLACER_TYPE,
-    onBackup: pluginConfig.onBackup || null,
-    onRestore: pluginConfig.onRestore || null,
   }
 
   const storeCreationHandlers = []


### PR DESCRIPTION
fix: https://github.com/infinitered/reactotron/issues/1082

We were not passing these configurations however we were already using them. This resolves both `except` and `isActionImportant` not working.